### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/nodejs-ci-npm.yml
+++ b/.github/workflows/nodejs-ci-npm.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
 
 name: Node.js CI (npm)
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/F88/x2md/security/code-scanning/3](https://github.com/F88/x2md/security/code-scanning/3)

To fix the problem, add a `permissions` block to the workflow file. The best practice is to add it at the top level (just after the `name:` and before `on:`), so it applies to all jobs unless overridden. For this workflow, the minimal required permission is likely `contents: read`, which allows the workflow to check out code but not to write to the repository. If any step requires more (such as uploading to Codecov with OIDC, which may require `id-token: write`), you can add that as needed, but based on the provided steps, `contents: read` is sufficient. The change should be made at the top of the file, after the `name:` line.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
