### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-publish-to-npmjs.yml
+++ b/.github/workflows/npm-publish-to-npmjs.yml
@@ -11,6 +11,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/F88/x2md/security/code-scanning/2](https://github.com/F88/x2md/security/code-scanning/2)

To fix the problem, add an explicit `permissions` block to the `build` job in `.github/workflows/npm-publish-to-npmjs.yml`. This block should grant only the minimal required permissions, which for a build job is typically `contents: read`. This change should be made directly under the `build:` job definition, before the `runs-on:` key (line 14). No additional imports or definitions are needed, as this is a YAML configuration change for GitHub Actions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
